### PR TITLE
[mms-lib] Fixed compilation against libsoup < 2.41.1

### DIFF
--- a/mms-lib/src/mms_task_http.c
+++ b/mms-lib/src/mms_task_http.c
@@ -22,8 +22,6 @@
 #  include <net/if.h>
 #endif
 
-#include <libsoup/soup.h>
-
 /* Appeared in libsoup somewhere between 2.41.5 and 2.41.90 */
 #ifndef SOUP_SESSION_LOCAL_ADDRESS
 #  define SOUP_SESSION_LOCAL_ADDRESS "local-address"

--- a/mms-lib/src/mms_task_http.h
+++ b/mms-lib/src/mms_task_http.h
@@ -16,10 +16,17 @@
 #define JOLLA_MMS_TASK_HTTP_H
 
 #include "mms_task.h"
-#include <libsoup/soup-status.h>
+#include <libsoup/soup.h>
 
-#if !SOUP_CHECK_VERSION(2,43,5)
+#ifdef SOUP_CHECK_VERSION
 /* SoupStatus was called SoupKnownStatusCode prior to 2.43.5 */
+#  define SOUP_STATUS_MISSING !SOUP_CHECK_VERSION(2,43,5)
+#else
+/* No SOUP_CHECK_VERSION macro prior to libsoup 2.41.1 */
+#  define SOUP_STATUS_MISSING 1
+#endif
+
+#if SOUP_STATUS_MISSING
 #  define SoupStatus SoupKnownStatusCode
 #endif
 


### PR DESCRIPTION
And it generally doesn't make sense to check for earlier versions with a macro that wasn't available in the earlier versions.
