### PR TITLE
[mms-engine] Fix incorrect parameter in mms_engine_handle_cancel

### DIFF
--- a/mms-engine/mms_engine.c
+++ b/mms-engine/mms_engine.c
@@ -288,12 +288,15 @@ gboolean
 mms_engine_handle_cancel(
     OrgNemomobileMmsEngine* proxy,
     GDBusMethodInvocation* call,
-    const char* id,
+    int database_id,
     MMSEngine* engine)
 {
+    const char *id = NULL;
+    if (database_id > 0) id = g_strdup_printf("%u", database_id);
     MMS_DEBUG_("%s", id);
     mms_dispatcher_cancel(engine->dispatcher, id);
     org_nemomobile_mms_engine_complete_cancel(proxy, call);
+    g_free(id);
     return TRUE;
 }
 


### PR DESCRIPTION
The cancel method should take a string id, but currently a few functions
are still defined with integer ids, including sendMessage and cancel.
sendMessage correctly converts the integer to a string, but cancel had a
bad cast that resulted in a crash when called with an integer id.

We should fix the parameter types on these methods at some point, which
will require a coordinated change with the MmsHandler. Until then, this
prevents the crash and makes the cancel method work as expected.
