### PR TITLE
[mms_dispatcher] Beware of tasks with NULL ids

### DIFF
--- a/mms-lib/src/mms_dispatcher.c
+++ b/mms-lib/src/mms_dispatcher.c
@@ -532,11 +532,11 @@ mms_dispatcher_cancel(
     GList* entry;
     for (entry = disp->tasks->head; entry; entry = entry->next) {
         MMSTask* task = entry->data;
-        if (!id || !strcmp(task->id, id)) {
+        if (mms_task_match_id(task, id)) {
             mms_task_cancel(task);
         }
     }
-    if (disp->active_task && (!id || !strcmp(disp->active_task->id, id))) {
+    if (mms_task_match_id(disp->active_task, id)) {
         mms_task_cancel(disp->active_task);
     }
 }

--- a/mms-lib/src/mms_task.c
+++ b/mms-lib/src/mms_task.c
@@ -298,6 +298,25 @@ mms_task_queue_and_unref(
     return ok;
 }
 
+gboolean
+mms_task_match_id(
+    MMSTask* task,
+    const char* id)
+{
+    if (!task) {
+        /* No task - no match */
+        return FALSE;
+    } else if (!id || !id[0]) {
+        /* A wildcard matching any task */
+        return TRUE;
+    } else if (!task->id || !task->id[0]) {
+        /* Only wildcard will match that */
+        return FALSE;
+    } else {
+        return !strcmp(task->id, id);
+    }
+}
+
 /**
  * Generates dummy task id if necessary.
  */

--- a/mms-lib/src/mms_task.h
+++ b/mms-lib/src/mms_task.h
@@ -144,6 +144,11 @@ mms_task_queue_and_unref(
     MMSTaskDelegate* delegate,
     MMSTask* task);
 
+gboolean
+mms_task_match_id(
+    MMSTask* task,
+    const char* id);
+
 const char*
 mms_task_make_id(
     MMSTask* task);


### PR DESCRIPTION
This should fix the recently observed crash in mms_dispatcher_cancel().
