### PR TITLE
[mms_attachment_image] Mark non-jpeg attachments as resizable

### DIFF
--- a/mms-lib/src/mms_attachment_image.c
+++ b/mms-lib/src/mms_attachment_image.c
@@ -317,7 +317,7 @@ void
 mms_attachment_image_init(
     MMSAttachmentImage* image)
 {
-#ifdef MMS_RESIZE_IMAGEMAGICK
+#if defined(MMS_RESIZE_IMAGEMAGICK) || defined(MMS_RESIZE_QT)
     image->attachment.flags |= MMS_ATTACHMENT_RESIZABLE;
 #endif
 }


### PR DESCRIPTION
if we have either ImageMagick or Qt available to do the resizing for us
