### PR TITLE
[mms_task_encode] Treat empty content type as no content type

### DIFF
--- a/mms-lib/src/mms_attachment.h
+++ b/mms-lib/src/mms_attachment.h
@@ -74,6 +74,10 @@ void
 mms_attachment_reset(
     MMSAttachment* attachment);
 
+char*
+mms_attachment_guess_content_type(
+    const char* path);
+
 gboolean
 mms_attachment_resize(
     MMSAttachment* attachment);

--- a/mms-lib/test/send/test_send.c
+++ b/mms-lib/test/send/test_send.c
@@ -80,8 +80,8 @@ static const MMSAttachmentInfo test_files_accept [] = {
 
 static const MMSAttachmentInfo test_files_accept_no_ext [] = {
     { "smil", NULL, NULL },
-    { "0001", "image/jpeg", "image1" },
-    { "0001", "image/jpeg", "image2" },
+    { "0001", NULL, "image1" },
+    { "0001", "", "image2" },
     { "test.text", "text/plain;charset=utf-8", "text" }
 };
 


### PR DESCRIPTION
This fixes the case if UI sends a large png file which needs to be resized AND we are using Qt to resize it AND file name has no extension AND content type is an empty string. This scenario didn't work before, now it does.
