### PR TITLE
[mms_task_encode] Don't encode empty subject

### DIFF
--- a/mms-lib/src/mms_task_encode.c
+++ b/mms-lib/src/mms_task_encode.c
@@ -152,7 +152,9 @@ mms_encode_job_encode(
         mms->sr.to = g_strdup(enc->to);
         mms->sr.cc = g_strdup(enc->cc);
         mms->sr.bcc = g_strdup(enc->bcc);
-        mms->sr.subject = g_strdup(enc->subject);
+        if (enc->subject && enc->subject[0]) {
+            mms->sr.subject = g_strdup(enc->subject);
+        }
         mms->sr.dr = ((flags & MMS_SEND_FLAG_REQUEST_DELIVERY_REPORT) != 0);
         mms->sr.rr = ((flags & MMS_SEND_FLAG_REQUEST_READ_REPORT) != 0);
         mms->sr.content_type = mms_unparse_http_content_type((char**)ct);

--- a/mms-send/mms-send.c
+++ b/mms-send/mms-send.c
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
     int ret = RET_ERR_CMDLINE;
     gboolean ok, verbose = FALSE, dr = FALSE, rr = FALSE;
     GError* error = NULL;
-    char* subject = NULL;
+    char* subject = "";
     GOptionEntry entries[] = {
         { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
           "Enable verbose output", NULL },


### PR DESCRIPTION
Empty subject is even worse than no subject at all because it may make the recipient think that it has a meaningful subject when in fact it doesn't.
