### PR TITLE
[mms-engine] Avoid using qmake to detect Qt version

### DIFF
--- a/mms-lib/Config.mak
+++ b/mms-lib/Config.mak
@@ -13,11 +13,7 @@ RESIZE_DEFINES = -DMMS_RESIZE_IMAGEMAGICK
 RESIZE_CFLAGS = $(shell pkg-config --cflags $(RESIZE_PKG))
 else
   ifeq ($(MMS_RESIZE),Qt)
-    ifeq ($(shell qmake --version | grep "Using Qt version 5"),)
-        RESIZE_PKG = QtGui
-    else
-        RESIZE_PKG = Qt5Gui
-    endif
+    RESIZE_PKG = Qt5Gui
     RESIZE_LIBS = -lstdc++
     RESIZE_DEFINES = -DMMS_RESIZE_QT
     RESIZE_CPPFLAGS = $(shell pkg-config --cflags $(RESIZE_PKG))


### PR DESCRIPTION
qtchooser systems will only have a default choice for qmake when a default package is installed, which we can't depend on. This causes build failures, see: https://build.merproject.org/package/rawlog?arch=armv7el&package=mms-engine&project=nemo%3Adevel%3Amw&repository=latest_armv7l

There is no reason to keep Qt4 support here.
