### PR TITLE
[mms-lib] Re-enabled Qt4 support

### DIFF
--- a/mms-lib/Config.mak
+++ b/mms-lib/Config.mak
@@ -13,7 +13,11 @@ RESIZE_DEFINES = -DMMS_RESIZE_IMAGEMAGICK
 RESIZE_CFLAGS = $(shell pkg-config --cflags $(RESIZE_PKG))
 else
   ifeq ($(MMS_RESIZE),Qt)
-    RESIZE_PKG = Qt5Gui
+    ifeq ($(shell pkg-config --exists Qt5Gui; echo $$?),0)
+        RESIZE_PKG = Qt5Gui
+    else
+        RESIZE_PKG = QtGui
+    endif
     RESIZE_LIBS = -lstdc++
     RESIZE_DEFINES = -DMMS_RESIZE_QT
     RESIZE_CPPFLAGS = $(shell pkg-config --cflags $(RESIZE_PKG))


### PR DESCRIPTION
This way it should work in OBS too. Qt4 support is required in order to run and debug mms-lib unit tests on a machine that doesn't have Qt5 installed.
