### PR TITLE
[mms_codec] Replaced Content-Disposition:Inline with Attachment

### DIFF
--- a/mms-lib/src/mms_codec.c
+++ b/mms-lib/src/mms_codec.c
@@ -2140,7 +2140,7 @@ static gboolean mms_encode_send_req_part_header(struct mms_attachment *part,
 
 		memcpy(ptr, &cd_val, cd_len);
 		ptr += cd_len;
-		*ptr++ = (guint8) 0x82; /* Inline = <Octet 130> */
+		*ptr++ = (guint8) 0x81; /* Attachment = <Octet 129> */
 		*ptr++ = (guint8) (WSP_PARAMETER_TYPE_FILENAME_DEFUNCT | 0x80);
 		strcpy(ptr, part->content_location);
 		ptr[cloc_len] = 0;


### PR DESCRIPTION
Ancient MMS server software doesn't know about Inline and rejects the PDU.
