### PR TITLE
GSettings backend for per-SIM settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ mms-lib/test/mms_lib_test.opt
 mms-ofono/mms-ofono.pro.user
 mms-handler-dbus/mms-handler-dbus.pro.user
 mms-handler-dbus/test/mms_handler_dbus_server/test_mms_handler_dbus_server.pro.user
+mms-settings-dconf/mms-settings-dconf.pro.user
 mms-dump/mms_dump.ncb
 mms-dump/mms_dump.opt

--- a/mms-engine/Makefile
+++ b/mms-engine/Makefile
@@ -4,6 +4,7 @@
 .PHONY: mms_lib_debug_lib mms_lib_release_lib
 .PHONY: mms_ofono_debug_lib mms_ofono_release_lib
 .PHONY: mms_handler_debug_lib mms_handler_release_lib
+.PHONY: mms_settings_debug_lib mms_settings_release_lib
 
 #
 # Pull in mms-lib configuration
@@ -15,7 +16,7 @@ include ../mms-lib/Config.mak
 # Required packages
 #
 
-PKGS = gio-unix-2.0 gio-2.0 glib-2.0
+PKGS = gio-unix-2.0 gio-2.0
 LIB_PKGS = libwspcodec libsoup-2.4 $(RESIZE_PKG) $(PKGS)
 
 #
@@ -73,6 +74,16 @@ MMS_HANDLER_DEBUG_LIB = $(MMS_HANDLER_BUILD_DIR)/debug/$(MMS_HANDLER_LIB)
 MMS_HANDLER_RELEASE_LIB = $(MMS_HANDLER_BUILD_DIR)/release/$(MMS_HANDLER_LIB)
 
 #
+# mms-settings-dconf
+#
+
+MMS_SETTINGS_LIB = libmms-settings-dconf.a
+MMS_SETTINGS_DIR = ../mms-settings-dconf
+MMS_SETTINGS_BUILD_DIR = $(MMS_SETTINGS_DIR)/build
+MMS_SETTINGS_DEBUG_LIB = $(MMS_SETTINGS_BUILD_DIR)/debug/$(MMS_SETTINGS_LIB)
+MMS_SETTINGS_RELEASE_LIB = $(MMS_SETTINGS_BUILD_DIR)/release/$(MMS_SETTINGS_LIB)
+
+#
 # Tools and flags
 #
 
@@ -85,7 +96,7 @@ RELEASE_DEFS =
 WARN = -Wall
 CFLAGS = -fPIC $(shell pkg-config --cflags $(PKGS)) -I. -I$(GEN_DIR) \
  -I$(MMS_LIB_DIR)/include -I$(MMS_OFONO_DIR)/include \
- -I$(MMS_HANDLER_DIR)/include -MMD
+ -I$(MMS_HANDLER_DIR)/include -I$(MMS_SETTINGS_DIR)/include -MMD
 
 ifndef KEEP_SYMBOLS
 KEEP_SYMBOLS = 0
@@ -107,11 +118,13 @@ LIBS = $(shell pkg-config --libs $(LIB_PKGS)) -lmagic -ljpeg $(RESIZE_LIBS)
 DEBUG_LIBS = \
   $(MMS_OFONO_DEBUG_LIB) \
   $(MMS_HANDLER_DEBUG_LIB) \
+  $(MMS_SETTINGS_DEBUG_LIB) \
   $(MMS_LIB_DEBUG_LIB) \
   $(LIBS)
 RELEASE_LIBS = \
   $(MMS_OFONO_RELEASE_LIB) \
   $(MMS_HANDLER_RELEASE_LIB) \
+  $(MMS_SETTINGS_RELEASE_LIB) \
   $(MMS_LIB_RELEASE_LIB) \
   $(LIBS)
 
@@ -135,19 +148,23 @@ GEN_FILES = $(GEN_SRC:%=$(GEN_DIR)/%)
 DEBUG_DEPS = \
   mms_lib_debug_lib \
   mms_ofono_debug_lib \
-  mms_handler_debug_lib
+  mms_handler_debug_lib \
+  mms_settings_debug_lib
 RELEASE_DEPS = \
   mms_lib_release_lib \
   mms_ofono_release_lib \
-  mms_handler_release_lib
+  mms_handler_release_lib \
+  mms_settings_release_lib
 DEBUG_EXE_DEPS = \
   $(MMS_LIB_DEBUG_LIB) \
   $(MMS_OFONO_DEBUG_LIB) \
-  $(MMS_HANDLER_DEBUG_LIB)
+  $(MMS_HANDLER_DEBUG_LIB) \
+  $(MMS_SETTINGS_DEBUG_LIB)
 RELEASE_EXE_DEPS = \
   $(MMS_LIB_RELEASE_LIB) \
   $(MMS_OFONO_RELEASE_LIB) \
-  $(MMS_HANDLER_RELEASE_LIB)
+  $(MMS_HANDLER_RELEASE_LIB) \
+  $(MMS_SETTINGS_RELEASE_LIB)
 DEPS = $(DEBUG_OBJS:%.o=%.d) $(RELEASE_OBJS:%.o=%.d)
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(strip $(DEPS)),)
@@ -178,6 +195,7 @@ cleaner: clean
 	make -C $(MMS_LIB_DIR) $(SUBMAKE_OPTS) clean
 	make -C $(MMS_OFONO_DIR) $(SUBMAKE_OPTS) clean
 	make -C $(MMS_HANDLER_DIR) $(SUBMAKE_OPTS) clean
+	make -C $(MMS_SETTINGS_DIR) $(SUBMAKE_OPTS) clean
 
 $(GEN_DIR):
 	mkdir -p $@
@@ -206,6 +224,12 @@ mms_handler_debug_lib:
 mms_handler_release_lib:
 	make -C $(MMS_HANDLER_DIR) $(SUBMAKE_OPTS) release
 
+mms_settings_debug_lib:
+	make -C $(MMS_SETTINGS_DIR) $(SUBMAKE_OPTS) debug
+
+mms_settings_release_lib:
+	make -C $(MMS_SETTINGS_DIR) $(SUBMAKE_OPTS) release
+
 $(MMS_LIB_DEBUG_LIB): mms_lib_debug_lib
 
 $(MMS_LIB_RELEASE_LIB): mms_lib_release_lib
@@ -217,6 +241,10 @@ $(MMS_OFONO_RELEASE_LIB): mms_ofono_release_lib
 $(MMS_HANDLER_DEBUG_LIB): mms_handler_debug_lib
 
 $(MMS_HANDLER_RELEASE_LIB): mms_handler_release_lib
+
+$(MMS_SETTINGS_DEBUG_LIB): mms_settings_debug_lib
+
+$(MMS_SETTINGS_RELEASE_LIB): mms_settings_release_lib
 
 $(GEN_DIR)/%.c: $(SPEC_DIR)/%.xml
 	gdbus-codegen --generate-c-code $(@:%.c=%) $<

--- a/mms-engine/mms-engine.pro
+++ b/mms-engine/mms-engine.pro
@@ -5,9 +5,11 @@ DBUS_INTERFACE_DIR = $$_PRO_FILE_PWD_
 MMS_LIB_DIR = $$_PRO_FILE_PWD_/../mms-lib
 MMS_OFONO_DIR = $$_PRO_FILE_PWD_/../mms-ofono
 MMS_HANDLER_DIR = $$_PRO_FILE_PWD_/../mms-handler-dbus
+MMS_SETTINGS_DIR = $$_PRO_FILE_PWD_/../mms-settings-dconf
 INCLUDEPATH += $$MMS_OFONO_DIR/include
 INCLUDEPATH += $$MMS_LIB_DIR/include
 INCLUDEPATH += $$MMS_HANDLER_DIR/include
+INCLUDEPATH += $$MMS_SETTINGS_DIR/include
 QMAKE_CFLAGS += -Wno-unused
 
 include(../mms-lib/mms-lib-config.pri)
@@ -34,11 +36,13 @@ CONFIG(debug, debug|release) {
     LIBS += $$MMS_OFONO_DIR/build/debug/libmms-ofono.a
     LIBS += $$MMS_HANDLER_DIR/build/debug/libmms-handler-dbus.a
     LIBS += $$MMS_LIB_DIR/build/debug/libmms-lib.a
+    LIBS += $$MMS_SETTINGS_DIR/build/debug/libmms-settings-dconf.a
 } else {
     DESTDIR = $$_PRO_FILE_PWD_/build/release
     LIBS += $$MMS_OFONO_DIR/build/release/libmms-ofono.a
     LIBS += $$MMS_HANDLER_DIR/build/release/libmms-handler-dbus.a
     LIBS += $$MMS_LIB_DIR/build/release/libmms-lib.a
+    LIBS += $$MMS_SETTINGS_DIR/build/release/libmms-settings-dconf.a
 }
 
 LIBS += -lmagic -ljpeg

--- a/mms-engine/mms_engine.c
+++ b/mms-engine/mms_engine.c
@@ -18,6 +18,7 @@
 #include "mms_lib_util.h"
 #include "mms_ofono_connman.h"
 #include "mms_handler_dbus.h"
+#include "mms_settings_dconf.h"
 #include "mms_log.h"
 
 /* Generated code */
@@ -418,17 +419,20 @@ mms_engine_new(
     if (cm) {
         MMSEngine* mms = g_object_new(MMS_TYPE_ENGINE, NULL);
         MMSHandler* handler = mms_handler_dbus_new();
-        MMSSettings* settings = mms_settings_default_new(config);
+        MMSSettings* settings = mms_settings_dconf_new(config);
 
         if (flags & MMS_ENGINE_FLAG_OVERRIDE_USER_AGENT) {
+            settings->flags |= MMS_SETTINGS_FLAG_OVERRIDE_USER_AGENT;
             g_free(settings->sim_defaults.user_agent);
             settings->sim_defaults.data.user_agent =
             settings->sim_defaults.user_agent = g_strdup(override->user_agent);
         }
         if (flags & MMS_ENGINE_FLAG_OVERRIDE_SIZE_LIMIT) {
+            settings->flags |= MMS_SETTINGS_FLAG_OVERRIDE_SIZE_LIMIT;
             settings->sim_defaults.data.size_limit = override->size_limit;
         }
         if (flags & MMS_ENGINE_FLAG_OVERRIDE_MAX_PIXELS) {
+            settings->flags |= MMS_SETTINGS_FLAG_OVERRIDE_MAX_PIXELS;
             settings->sim_defaults.data.max_pixels = override->max_pixels;
         }
 

--- a/mms-lib/include/mms_lib_log.h
+++ b/mms-lib/include/mms_lib_log.h
@@ -19,6 +19,7 @@
 
 #define MMS_LIB_LOG_MODULES(log) \
     log(mms_dispatcher_log)\
+    log(mms_settings_log)\
     log(mms_handler_log)\
     log(mms_message_log)\
     log(mms_attachment_log)\

--- a/mms-lib/include/mms_settings.h
+++ b/mms-lib/include/mms_settings.h
@@ -45,6 +45,12 @@ struct mms_settings {
     GObject object;
     const MMSConfig* config;
     MMSSettingsSimDataCopy sim_defaults;
+    unsigned int flags;
+
+#define MMS_SETTINGS_FLAG_OVERRIDE_USER_AGENT   (0x01)
+#define MMS_SETTINGS_FLAG_OVERRIDE_SIZE_LIMIT   (0x02)
+#define MMS_SETTINGS_FLAG_OVERRIDE_MAX_PIXELS   (0x04)
+#define MMS_SETTINGS_FLAG_OVERRIDE_ALLOW_DR     (0x08)
 };
 
 /* Class */
@@ -99,6 +105,14 @@ mms_settings_sim_data_copy_new(
 void
 mms_settings_sim_data_copy_free(
     MMSSettingsSimDataCopy* data);
+
+void
+mms_settings_sim_data_copy(
+    MMSSettingsSimDataCopy* dest,
+    const MMSSettingsSimData* src);
+
+#define mms_settings_sim_data_reset(data) \
+    mms_settings_sim_data_copy(data,NULL)
 
 #endif /* JOLLA_MMS_SETTINGS_H */
 

--- a/mms-lib/src/mms_settings.c
+++ b/mms-lib/src/mms_settings.c
@@ -46,7 +46,6 @@ mms_settings_sim_data_default(
     data->allow_dr = MMS_SETTINGS_DEFAULT_ALLOW_DR;
 }
 
-static
 void
 mms_settings_sim_data_copy(
     MMSSettingsSimDataCopy* dest,
@@ -79,7 +78,7 @@ mms_settings_sim_data_copy_free(
     MMSSettingsSimDataCopy* copy)
 {
     if (copy) {
-        g_free(copy->user_agent);
+        mms_settings_sim_data_reset(copy);
         g_free(copy);
     }
 }
@@ -130,7 +129,7 @@ mms_settings_finalize(
     GObject* object)
 {
     MMSSettings* settings = MMS_SETTINGS(object);
-    g_free(settings->sim_defaults.user_agent);
+    mms_settings_sim_data_reset(&settings->sim_defaults);
     G_OBJECT_CLASS(mms_settings_parent_class)->finalize(object);
 }
 

--- a/mms-settings-dconf/Makefile
+++ b/mms-settings-dconf/Makefile
@@ -1,0 +1,107 @@
+# -*- Mode: makefile-gmake -*-
+
+.PHONY: clean all debug release
+
+# Required packages
+PKGS = gio-2.0
+
+#
+# Default target
+#
+
+all: debug release
+
+#
+# Sources
+#
+
+SRC = mms_settings_dconf.c
+
+#
+# Directories
+#
+
+SRC_DIR = src
+INCLUDE_DIR = include
+BUILD_DIR = build
+MMS_LIB_INCLUDE = ../mms-lib/include
+DEBUG_BUILD_DIR = $(BUILD_DIR)/debug
+RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+
+#
+# Tools and flags
+#
+
+CC = $(CROSS_COMPILE)gcc
+LD = $(CC)
+ARFLAGS = rc
+DEBUG_FLAGS = -g
+RELEASE_FLAGS = -O2
+DEBUG_DEFS = -DDEBUG
+RELEASE_DEFS =
+WARNINGS = -Wall
+INCLUDES = -I$(SRC_DIR) -I$(INCLUDE_DIR) -I$(MMS_LIB_INCLUDE)
+CFLAGS += $(WARNINGS) $(INCLUDES) $(shell pkg-config --cflags $(PKGS)) \
+  -fPIC -MMD
+
+ifndef KEEP_SYMBOLS
+KEEP_SYMBOLS = 0
+endif
+
+ifneq ($(KEEP_SYMBOLS),0)
+RELEASE_FLAGS += -g
+endif
+
+DEBUG_CFLAGS = $(DEBUG_FLAGS) $(DEBUG_DEFS) $(CFLAGS)
+RELEASE_CFLAGS = $(RELEASE_FLAGS) $(RELEASE_DEFS) $(CFLAGS)
+
+#
+# Files
+#
+
+
+DEBUG_OBJS = $(SRC:%.c=$(DEBUG_BUILD_DIR)/%.o)
+RELEASE_OBJS = $(SRC:%.c=$(RELEASE_BUILD_DIR)/%.o)
+
+#
+# Dependencies
+#
+
+DEPS = $(DEBUG_OBJS:%.o=%.d) $(RELEASE_OBJS:%.o=%.d)
+ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(DEPS)),)
+-include $(DEPS)
+endif
+endif
+
+#
+# Rules
+#
+LIB = libmms-settings-dconf.a
+DEBUG_LIB = $(DEBUG_BUILD_DIR)/$(LIB)
+RELEASE_LIB = $(RELEASE_BUILD_DIR)/$(LIB)
+
+debug: $(DEBUG_LIB)
+
+release: $(RELEASE_LIB) 
+
+clean:
+	rm -fr $(BUILD_DIR) *~ $(SRC_DIR)/*~ $(INCLUDE_DIR)/*~
+
+$(DEBUG_BUILD_DIR):
+	mkdir -p $@
+
+$(RELEASE_BUILD_DIR):
+	mkdir -p $@
+
+$(DEBUG_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(WARN) $(DEBUG_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(RELEASE_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(WARN) $(RELEASE_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(DEBUG_LIB): $(DEBUG_BUILD_DIR) $(DEBUG_OBJS)
+	$(AR) $(ARFLAGS) $@ $(DEBUG_OBJS)
+
+$(RELEASE_LIB): $(RELEASE_BUILD_DIR) $(RELEASE_OBJS)
+	$(AR) $(ARFLAGS) $@ $(RELEASE_OBJS)

--- a/mms-settings-dconf/include/mms_settings_dconf.h
+++ b/mms-settings-dconf/include/mms_settings_dconf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014 Jolla Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef JOLLA_MMS_SETTINGS_DCONF_H
+#define JOLLA_MMS_SETTINGS_DCONF_H
+
+#include "mms_settings.h"
+
+MMSSettings*
+mms_settings_dconf_new(
+    const MMSConfig* config);
+
+#endif /* JOLLA_MMS_SETTINGS_DCONF_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/mms-settings-dconf/mms-settings-dconf.pro
+++ b/mms-settings-dconf/mms-settings-dconf.pro
@@ -1,0 +1,19 @@
+TEMPLATE = lib
+CONFIG += staticlib
+CONFIG -= qt
+CONFIG += link_pkgconfig
+PKGCONFIG += glib-2.0 gio-2.0 gio-unix-2.0
+INCLUDEPATH += include
+INCLUDEPATH += ../mms-lib/include
+QMAKE_CFLAGS += -Wno-unused
+
+CONFIG(debug, debug|release) {
+  DEFINES += DEBUG
+  DESTDIR = $$_PRO_FILE_PWD_/build/debug
+} else {
+  DESTDIR = $$_PRO_FILE_PWD_/build/release
+}
+
+SOURCES += src/mms_settings_dconf.c
+HEADERS += include/mms_settings_dconf.h
+OTHER_FILES += spec/org.nemomobile.mms.sim.gschema.xml

--- a/mms-settings-dconf/spec/org.nemomobile.mms.sim.gschema.xml
+++ b/mms-settings-dconf/spec/org.nemomobile.mms.sim.gschema.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <!-- Path is /IMSI/ -->
+  <schema id="org.nemomobile.mms.sim">
+    <key type="s" name="user-agent">
+      <default>'Mozilla/5.0 (Sailfish; Jolla)'</default>
+      <summary>User-Agent string.</summary>
+      <description>The value of User-Agent header to use when communicating with the MMS server.</description>
+    </key>
+    <key type="u" name="max-message-size">
+      <default>307200</default>
+      <summary>Maximum size of an outbound MMS message.</summary>
+      <description>Maximum size of an outbound MMS message.</description>
+    </key>
+    <key type="u" name="max-pixels">
+      <default>3000000</default>
+      <summary>Maximum number of pixels in an outbound image.</summary>
+      <description>Maximum number of pixels in an outbound image.</description>
+    </key>
+    <key type="b" name="allow-delivery-reports">
+      <default>true</default>
+      <summary>Allow sending delivery reports.</summary>
+      <description>Whether or not we (as a recipient) allow sending delivery reports.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/mms-settings-dconf/src/mms_settings_dconf.c
+++ b/mms-settings-dconf/src/mms_settings_dconf.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2014 Jolla Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include "mms_settings_dconf.h"
+#include <gio/gio.h>
+
+/* Logging */
+#define MMS_LOG_MODULE_NAME mms_settings_log
+#include "mms_lib_log.h"
+MMS_LOG_MODULE_DEFINE("mms-settings-dconf");
+
+typedef MMSSettingsClass MMSSettingsDconfClass;
+typedef struct mms_settings_dconf {
+    MMSSettings settings;
+    MMSSettingsSimDataCopy imsi_data;
+    char* imsi;
+    GSettings* gs;
+    gulong gs_changed_signal_id;
+} MMSSettingsDconf;
+
+G_DEFINE_TYPE(MMSSettingsDconf, mms_settings_dconf, MMS_TYPE_SETTINGS);
+#define MMS_TYPE_SETTINGS_DCONF mms_settings_dconf_get_type()
+#define MMS_SETTINGS_DCONF_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS((obj), \
+        MMS_TYPE_SETTINGS_DCONF, MMSSettingsDconfClass))
+#define MMS_SETTINGS_DCONF(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), \
+        MMS_TYPE_SETTINGS_DCONF, MMSSettingsDconf))
+
+#define MMS_DCONF_SCHEMA_ID         "org.nemomobile.mms.sim"
+#define MMS_DCONF_CHANGED_SIGNAL    "changed"
+#define MMS_DCONF_PATH_PREFIX       "/"
+
+#define MMS_DCONF_KEY_USER_AGENT    "user-agent"
+#define MMS_DCONF_KEY_SIZE_LIMIT    "max-message-size"
+#define MMS_DCONF_KEY_MAX_PIXELS    "max-pixels"
+#define MMS_DCONF_KEY_ALLOW_DR      "allow-delivery-reports"
+
+typedef struct mms_settings_dconf_key {
+    const char* key;
+    void (*fn_update)(MMSSettingsDconf* dconf, const char* key);
+} MMSSettingsDconfKey;
+
+static
+void
+mms_settings_dconf_update_user_agent(
+    MMSSettingsDconf* dconf,
+    const char* key)
+{
+    char* value = g_settings_get_string(dconf->gs, key);
+    if (dconf->settings.flags & MMS_SETTINGS_FLAG_OVERRIDE_USER_AGENT) {
+        MMS_DEBUG("%s = %s (ignored)", key, value);
+        g_free(value);
+    } else {
+        MMSSettingsSimDataCopy* copy = &dconf->imsi_data;
+        g_free(copy->user_agent);
+        copy->data.user_agent =
+        copy->user_agent = value;
+        MMS_DEBUG("%s = %s", key, copy->data.user_agent);
+    }
+}
+
+static
+void
+mms_settings_dconf_update_size_limit(
+    MMSSettingsDconf* dconf,
+    const char* key)
+{
+    const guint value = g_settings_get_uint(dconf->gs, key);
+    if (dconf->settings.flags & MMS_SETTINGS_FLAG_OVERRIDE_SIZE_LIMIT) {
+        MMS_DEBUG("%s = %u (ignored)", key, value);
+    } else {
+        MMS_DEBUG("%s = %u", key, value);
+        dconf->imsi_data.data.size_limit = value;
+    }
+}
+
+static
+void
+mms_settings_dconf_update_max_pixels(
+    MMSSettingsDconf* dconf,
+    const char* key)
+{
+    const guint value = g_settings_get_uint(dconf->gs, key);
+    if (dconf->settings.flags & MMS_SETTINGS_FLAG_OVERRIDE_MAX_PIXELS) {
+        MMS_DEBUG("%s = %u (ignored)", key, value);
+    } else {
+        MMS_DEBUG("%s = %u", key, value);
+        dconf->imsi_data.data.max_pixels = value;
+    }
+}
+
+static
+void
+mms_settings_dconf_update_max_allow_dr(
+    MMSSettingsDconf* dconf,
+    const char* key)
+{
+    const gboolean value = g_settings_get_boolean(dconf->gs, key);
+    if (dconf->settings.flags & MMS_SETTINGS_FLAG_OVERRIDE_ALLOW_DR) {
+        MMS_DEBUG("%s = %s (ignored)", key, value ? "true" : "false");
+    } else {
+        MMS_DEBUG("%s = %s", key, value ? "true" : "false");
+        dconf->imsi_data.data.allow_dr = value;
+    }
+}
+
+static const MMSSettingsDconfKey mms_settings_dconf_keys[] = {
+    { MMS_DCONF_KEY_USER_AGENT, mms_settings_dconf_update_user_agent   },
+    { MMS_DCONF_KEY_SIZE_LIMIT, mms_settings_dconf_update_size_limit   },
+    { MMS_DCONF_KEY_MAX_PIXELS, mms_settings_dconf_update_max_pixels   },
+    { MMS_DCONF_KEY_ALLOW_DR,   mms_settings_dconf_update_max_allow_dr },
+};
+
+static
+void
+mms_settings_dconf_changed(
+    GSettings* gs,
+    const gchar* key,
+    gpointer user_data)
+{
+    unsigned int i;
+    MMSSettingsDconf* dconf = user_data;
+    MMS_ASSERT(dconf->gs == gs);
+    for (i=0; i<G_N_ELEMENTS(mms_settings_dconf_keys); i++) {
+        if (!strcmp(key, mms_settings_dconf_keys[i].key)) {
+            mms_settings_dconf_keys[i].fn_update(dconf, key);
+            return;
+        }
+    }
+    MMS_DEBUG("%s changed", key);
+}
+
+static
+void
+mms_settings_dconf_disconnect(
+    MMSSettingsDconf* dconf)
+{
+    if (dconf->imsi) {
+        g_free(dconf->imsi);
+        dconf->imsi = NULL;
+    }
+    if (dconf->gs) {
+        if (dconf->gs_changed_signal_id) {
+            g_signal_handler_disconnect(dconf->gs,
+                dconf->gs_changed_signal_id);
+            dconf->gs_changed_signal_id = 0;
+        }
+        g_object_unref(dconf->gs);
+        dconf->gs = NULL;
+    }
+}
+
+static
+const MMSSettingsSimData*
+mms_settings_dconf_get_sim_data(
+    MMSSettings* settings,
+    const char* imsi)
+{
+    MMSSettingsDconf* dconf = MMS_SETTINGS_DCONF(settings);
+    if (imsi) {
+        if (!dconf->imsi || strcmp(dconf->imsi, imsi)) {
+            char* path = g_strconcat(MMS_DCONF_PATH_PREFIX, imsi, "/", NULL);
+            mms_settings_dconf_disconnect(dconf);
+            mms_settings_sim_data_copy(&dconf->imsi_data,
+                &settings->sim_defaults.data);
+
+            /* Attach to the new path */
+            dconf->gs = g_settings_new_with_path(MMS_DCONF_SCHEMA_ID, path);
+            if (dconf->gs) {
+                unsigned int i;
+                dconf->imsi = g_strdup(imsi);
+
+                /* Query current settings */
+                for (i=0; i<G_N_ELEMENTS(mms_settings_dconf_keys); i++) {
+                    mms_settings_dconf_keys[i].fn_update(dconf,
+                    mms_settings_dconf_keys[i].key);
+                }
+
+                /* And register for change notifications */
+                dconf->gs_changed_signal_id = g_signal_connect(
+                    dconf->gs, MMS_DCONF_CHANGED_SIGNAL,
+                    G_CALLBACK(mms_settings_dconf_changed), dconf);
+            }
+            g_free(path);
+        }
+        return &dconf->imsi_data.data;
+    } else {
+        return &dconf->settings.sim_defaults.data;
+    }
+}
+
+static
+void
+mms_settings_dconf_dispose(
+    GObject* object)
+{
+    mms_settings_dconf_disconnect(MMS_SETTINGS_DCONF(object));
+    G_OBJECT_CLASS(mms_settings_dconf_parent_class)->dispose(object);
+}
+
+static
+void
+mms_settings_dconf_finalize(
+    GObject* object)
+{
+    MMSSettingsDconf* dconf = MMS_SETTINGS_DCONF(object);
+    mms_settings_dconf_disconnect(dconf);
+    mms_settings_sim_data_reset(&dconf->imsi_data);
+    G_OBJECT_CLASS(mms_settings_dconf_parent_class)->finalize(object);
+}
+
+/**
+ * Per class initializer
+ */
+static
+void
+mms_settings_dconf_class_init(
+    MMSSettingsClass* klass)
+{
+    klass->fn_get_sim_data = mms_settings_dconf_get_sim_data;
+    G_OBJECT_CLASS(klass)->dispose = mms_settings_dconf_dispose;
+    G_OBJECT_CLASS(klass)->finalize = mms_settings_dconf_finalize;
+}
+
+/**
+ * Per instance initializer
+ */
+static
+void
+mms_settings_dconf_init(
+    MMSSettingsDconf* dconf)
+{
+}
+
+/**
+ * Instantiates GSettings/Dconf settings implementation.
+ */
+MMSSettings*
+mms_settings_dconf_new(
+    const MMSConfig* config)
+{
+    MMSSettings* settings = g_object_new(MMS_TYPE_SETTINGS_DCONF, NULL);
+    settings->config = config;
+    return settings;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/rpm/mms-engine.spec
+++ b/rpm/mms-engine.spec
@@ -23,9 +23,11 @@ BuildRequires:  pkgconfig(Qt5Gui)
 
 %define src mms-engine
 %define exe mms-engine
+%define schema org.nemomobile.mms.sim
 %define dbusname org.nemomobile.MmsEngine
 %define dbusconfig %{_datadir}/dbus-1/system-services
 %define dbuspolicy %{_sysconfdir}/dbus-1/system.d
+%define glibschemas  %{_datadir}/glib-2.0/schemas
 
 # Activation method:
 %define pushconfig %{_sysconfdir}/ofono/push_forwarder.d
@@ -56,19 +58,28 @@ mkdir -p %{buildroot}%{_sbindir}
 mkdir -p %{buildroot}%{dbusconfig}
 mkdir -p %{buildroot}%{dbuspolicy}
 mkdir -p %{buildroot}%{pushconfig}
+mkdir -p %{buildroot}%{glibschemas}
 mkdir -p %{buildroot}%{_prefix}/bin/
 cp %{src}/build/release/%{exe} %{buildroot}%{_sbindir}/
 cp %{src}/%{dbusname}.service %{buildroot}%{dbusconfig}/
 cp %{src}/%{dbusname}.dbus.conf %{buildroot}%{dbuspolicy}/%{dbusname}.conf
 cp %{src}/%{dbusname}.push.conf %{buildroot}%{pushconfig}/%{dbusname}.conf
+cp mms-settings-dconf/spec/%{schema}.gschema.xml %{buildroot}%{glibschemas}/
 cp mms-dump/build/release/mms-dump %{buildroot}%{_prefix}/bin/
 cp mms-send/build/release/mms-send %{buildroot}%{_prefix}/bin/
+
+%post
+glib-compile-schemas %{glibschemas}
+
+%postun
+glib-compile-schemas %{glibschemas}
 
 %check
 make -C mms-lib/test test
 
 %files
 %defattr(-,root,root,-)
+%config %{glibschemas}/%{schema}.gschema.xml
 %config %{dbuspolicy}/%{dbusname}.conf
 %config %{pushconfig}/%{dbusname}.conf
 %{dbusconfig}/%{dbusname}.service


### PR DESCRIPTION
Per-SIM settings can be configured now from the command line like this:

gsettings set org.nemomobile.mms.sim:/250992200212687/ max-message-size 614400

It shouldn't be much of a problem to write a UI for that.
