### PR TITLE
Added Name parameter to the part's Content-Type header

### DIFF
--- a/mms-lib/test/send/test_send.c
+++ b/mms-lib/test/send/test_send.c
@@ -80,9 +80,9 @@ typedef struct test {
 } Test;
 
 static const MMSAttachmentInfo test_files_accept [] = {
-    { "smil", NULL, NULL },
-    { "0001.jpg", "image/jpeg", "image" },
-    { "test.txt", "text/plain;charset=utf-8", "text" }
+    { "smil", "application/smil;charset=us-ascii", NULL },
+    { "0001.jpg", "image/jpeg;name=0001.jpg", "image" },
+    { "test.txt", "text/plain;charset=utf-8;name=wrong.name", "text" }
 };
 
 static const MMSAttachmentInfo test_files_accept_no_ext [] = {


### PR DESCRIPTION
That's one of the ways to pass the name of the attachment to the recipient. And this is what most MMS implementations are doing nowadays.
