### PR TITLE
Additional check for Message-ID in M-Retrieve.conf

### DIFF
--- a/mms-lib/src/mms_task_decode.c
+++ b/mms-lib/src/mms_task_decode.c
@@ -211,8 +211,11 @@ mms_task_decode_process_pdu(
     if (mms_message_decode(data, len, pdu)) {
         if (pdu->type == MMS_MESSAGE_TYPE_RETRIEVE_CONF) {
             struct mms_retrieve_conf* rc = &pdu->rc;
-            if (rc->retrieve_status == 0 /* no status at all */ ||
-                rc->retrieve_status == MMS_MESSAGE_RETRIEVE_STATUS_OK) {
+            /* Message-ID must be present only if the M-Retrieve.conf PDU
+             * includes the requested MM */
+            if (rc->msgid &&
+               (rc->retrieve_status == 0 /* no status at all */ ||
+                rc->retrieve_status == MMS_MESSAGE_RETRIEVE_STATUS_OK)) {
                 MMSMessage* msg;
                 msg = mms_task_decode_retrieve_conf(task, pdu, data, len);
                 if (msg) {


### PR DESCRIPTION
Message-ID must be present only if the M-Retrieve.conf PDU includes the requested MM. If it doesn't include the message then X-Mms-Retrieve-Status should indicate the error but just in case let's check Message-ID as well.
