### PR TITLE
Make sure that context deactivation call completes before we exit

### DIFF
--- a/mms-lib/include/mms_connection.h
+++ b/mms-lib/include/mms_connection.h
@@ -82,6 +82,9 @@ mms_connection_close(
 
 #define mms_connection_is_open(connection) \
     (mms_connection_state(connection) == MMS_CONNECTION_STATE_OPEN)
+#define mms_connection_is_active(connection) ((connection) && \
+    ((connection)->state == MMS_CONNECTION_STATE_OPEN || \
+     (connection)->state == MMS_CONNECTION_STATE_OPENING))
 
 #endif /* JOLLA_MMS_CONNECTION_H */
 

--- a/mms-ofono/src/mms_ofono_connection.c
+++ b/mms-ofono/src/mms_ofono_connection.c
@@ -237,6 +237,7 @@ mms_ofono_connection_dispose(
 {
     MMSOfonoConnection* ofono = MMS_OFONO_CONNECTION(object);
     MMS_VERBOSE_("%p", ofono);
+    MMS_ASSERT(!mms_connection_is_active(&ofono->connection));
     if (ofono->property_change_signal_id) {
         g_signal_handler_disconnect(ofono->proxy,
             ofono->property_change_signal_id);


### PR DESCRIPTION
Otherwise there is a chance that org.ofono.ConnectionContext.SetProperty(Active,false) call gets canceled before it reaches ofono and MMS context may remain active after mms-engine exits.
