### PR TITLE
Notify handler when read report sending is finished

### DIFF
--- a/mms-handler-dbus/spec/org.nemomobile.MmsHandler.xml
+++ b/mms-handler-dbus/spec/org.nemomobile.MmsHandler.xml
@@ -254,6 +254,29 @@
     <!--
         ===============================================================
 
+        Reports completion status of read report send request submitted
+        by org.nemomobile.MmsEngine.sendReadReport call.
+
+        ===============================================================
+    -->
+    <method name="readReportSendStatus">
+      <!--
+          Database record id.
+      -->
+      <arg direction="in" type="s" name="recId"/>
+      <!--
+          Indicates the result of the operation:
+
+          0: Read report has been sent
+          1: Transient failure (wrong SIM, no coverage, I/O error)
+          2: Permanent failure (error from the operator)
+      -->
+      <arg direction="in" type="i" name="status"/>
+    </method>
+
+    <!--
+        ===============================================================
+
         Message delivery notification. These are only coming if
         delivery reports were requested when message was sent.
 

--- a/mms-handler-dbus/src/mms_handler_dbus.c
+++ b/mms-handler-dbus/src/mms_handler_dbus.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013-2014 Jolla Ltd.
+ * Copyright (C) 2013-2015 Jolla Ltd.
+ * Contact: Slava Monich <slava.monich@jolla.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -444,6 +445,24 @@ mms_handler_dbus_read_report(
     return FALSE;
 }
 
+/* Done with sending MMS read report */
+gboolean
+mms_handler_dbus_read_report_send_status(
+    MMSHandler* handler,
+    const char* id,
+    MMS_READ_REPORT_STATUS status)
+{
+    OrgNemomobileMmsHandler* proxy = mms_handler_dbus_connect(handler);
+    if (id && id[0] && proxy) {
+        mms_handler_ref(handler);
+        mms_handler_busy_inc(handler);
+        org_nemomobile_mms_handler_call_read_report_send_status(proxy, id,
+            status, NULL, mms_handler_dbus_call_done, handler);
+        return TRUE;
+    }
+    return FALSE;
+}
+
 /**
  * First stage of deinitialization (release all references).
  * May be called more than once in the lifetime of the object.
@@ -496,6 +515,8 @@ mms_handler_dbus_class_init(
     klass->fn_message_sent = mms_handler_dbus_message_sent;
     klass->fn_delivery_report = mms_handler_dbus_delivery_report;
     klass->fn_read_report = mms_handler_dbus_read_report;
+    klass->fn_read_report_send_status =
+        mms_handler_dbus_read_report_send_status;
     object_class->dispose = mms_handler_dbus_dispose;
     object_class->finalize = mms_handler_dbus_finalize;
 }

--- a/mms-lib/include/mms_handler.h
+++ b/mms-lib/include/mms_handler.h
@@ -57,6 +57,14 @@ typedef enum _mms_delivery_status {
 /* Read status */
 typedef MMSReadStatus MMS_READ_STATUS;
 
+/* Read report status */
+typedef enum _mms_read_report_status {
+    MMS_READ_REPORT_STATUS_INVALID = -1,
+    MMS_READ_REPORT_STATUS_OK,
+    MMS_READ_REPORT_STATUS_IO_ERROR,
+    MMS_READ_REPORT_STATUS_PERMANENT_ERROR
+} MMS_READ_REPORT_STATUS;
+
 /* Handler event callback */
 typedef void
 (*mms_handler_event_fn)(
@@ -156,6 +164,12 @@ typedef struct mms_handler_class {
         const char* recipient,      /* Recipient's phone number */
         MMS_READ_STATUS rs);        /* Read status */
 
+    /* Done with sending MMS read report */
+    gboolean (*fn_read_report_send_status)(
+        MMSHandler* handler,        /* Handler instance */
+        const char* id,             /* Handler record id */
+        MMS_READ_REPORT_STATUS s);  /* Status */
+
 } MMSHandlerClass;
 
 GType mms_handler_get_type(void);
@@ -230,6 +244,12 @@ mms_handler_read_report(
     const char* msgid,              /* Message id assigned by operator */
     const char* recipient,          /* Recipient's phone number */
     MMS_READ_STATUS rs);            /* Read status */
+
+gboolean
+mms_handler_read_report_send_status(
+    MMSHandler* handler,            /* Handler instance */
+    const char* id,                 /* Handler record id */
+    MMS_READ_REPORT_STATUS status); /* Status */
 
 void
 mms_handler_busy_update(

--- a/mms-lib/src/mms_handler.c
+++ b/mms-lib/src/mms_handler.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013-2014 Jolla Ltd.
+ * Copyright (C) 2013-2015 Jolla Ltd.
+ * Contact: Slava Monich <slava.monich@jolla.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -258,6 +259,22 @@ mms_handler_read_report(
             return klass->fn_read_report(h, imsi, msgid, recipient, rs);
         }
         MMS_ERR("mms_handler_read_report not implemented");
+    }
+    return FALSE;
+}
+
+gboolean
+mms_handler_read_report_send_status(
+    MMSHandler* h,
+    const char* id,
+    MMS_READ_REPORT_STATUS status)
+{
+    if (h) {
+        MMSHandlerClass* klass = MMS_HANDLER_GET_CLASS(h);
+        if (klass->fn_read_report_send_status) {
+            return klass->fn_read_report_send_status(h, id, status);
+        }
+        MMS_ERR("mms_handler_read_report_send_status not implemented");
     }
     return FALSE;
 }


### PR DESCRIPTION
New method `readReportSendStatus` has been added to `org.nemomobile.MmsHandler` D-Bus interface. It's called when `mms-engine` is done with sending the read report, successfully or not. If read report sending fails, the handler has a chance to retry.